### PR TITLE
Add multichannel volume

### DIFF
--- a/spec/ndx-microscopy.extensions.yaml
+++ b/spec/ndx-microscopy.extensions.yaml
@@ -247,13 +247,79 @@ groups:
       - frames
       - height
       - width
-      - depth
+      - depths
       shape:
       - null
       - null
       - null
       - null
     links:
+    - name: imaging_space
+      doc: Link to VolumetricImagingSpace object containing metadata about the region of physical space this imaging data
+        was recorded from.
+      target_type: VolumetricImagingSpace
+
+  - neurodata_type_def: MultiChannelMicroscopyVolume
+    neurodata_type_inc: NWBData
+    doc: Static (not time-varying) volumetric imaging data acquired from multiple optical channels.
+    attributes:
+    - name: description
+      dtype: text
+      doc: Description of the MultiChannelVolume.
+      required: false
+    - name: unit
+      dtype: text
+      doc: Base unit of measurement for working with the data. Actual stored values are
+        not necessarily stored in these units. To access the data in these units,
+        multiply 'data' by 'conversion' and add 'offset'.
+    - name: conversion
+      dtype: float32
+      default_value: 1.0
+      doc: Scalar to multiply each element in data to convert it to the specified 'unit'.
+        If the data are stored in acquisition system units or other units
+        that require a conversion to be interpretable, multiply the data by 'conversion'
+        to convert the data to the specified 'unit'. e.g. if the data acquisition system
+        stores values in this object as signed 16-bit integers (int16 range
+        -32,768 to 32,767) that correspond to a 5V range (-2.5V to 2.5V), and the data
+        acquisition system gain is 8000X, then the 'conversion' multiplier to get from
+        raw data acquisition values to recorded volts is 2.5/32768/8000 = 9.5367e-9.
+      required: false
+    - name: offset
+      dtype: float32
+      default_value: 0.0
+      doc: Scalar to add to the data after scaling by 'conversion' to finalize its coercion
+        to the specified 'unit'. Two common examples of this include (a) data stored in an
+        unsigned type that requires a shift after scaling to re-center the data,
+        and (b) specialized recording devices that naturally cause a scalar offset with
+        respect to the true units.
+      required: false
+    datasets:
+    - name: data
+      doc: Recorded imaging data, shaped by (frame height, frame width, number of depth planes, number of optical
+        channels).
+      dtype: numeric
+      dims:
+      - height
+      - width
+      - depths
+      - channels
+      shape:
+      - null
+      - null
+      - null
+      - null
+    links:
+    - name: microscope
+      doc: Link to a Microscope object containing metadata about the device used to acquire this imaging data.
+      target_type: Microscope
+    - name: light_source
+      doc: Link to a LightSource object containing metadata about the device used to illuminate the imaging space.
+      target_type: LightSource
+    # TODO: figure out best way to link to list of optical channels
+    - name: optical_channels
+      doc: Link to an ordered list of MicroscopyOpticalChannel objects containing metadata about the indicator and
+        filters used to collect this data.
+      target_type: MicroscopyOpticalChannel
     - name: imaging_space
       doc: Link to VolumetricImagingSpace object containing metadata about the region of physical space this imaging data
         was recorded from.

--- a/src/pynwb/ndx_microscopy/__init__.py
+++ b/src/pynwb/ndx_microscopy/__init__.py
@@ -30,6 +30,7 @@ MicroscopySeries = get_class("MicroscopySeries", extension_name)
 PlanarMicroscopySeries = get_class("PlanarMicroscopySeries", extension_name)
 VariableDepthMicroscopySeries = get_class("VariableDepthMicroscopySeries", extension_name)
 VolumetricMicroscopySeries = get_class("VolumetricMicroscopySeries", extension_name)
+MultiChannelMicroscopyVolume = get_class("MultiChannelMicroscopyVolume", extension_name)
 
 __all__ = [
     "Microscope",
@@ -42,4 +43,5 @@ __all__ = [
     "PlanarMicroscopySeries",
     "VariableDepthMicroscopySeries",
     "VolumetricMicroscopySeries",
+    "MultiChannelMicroscopyVolume",
 ]

--- a/src/pynwb/ndx_microscopy/testing/__init__.py
+++ b/src/pynwb/ndx_microscopy/testing/__init__.py
@@ -2,6 +2,7 @@ from ._mock import (
     mock_LightSource,
     mock_Microscope,
     mock_MicroscopyOpticalChannel,
+    mock_MultiChannelMicroscopyVolume,
     mock_PlanarImagingSpace,
     mock_PlanarMicroscopySeries,
     mock_VariableDepthMicroscopySeries,
@@ -18,4 +19,5 @@ __all__ = [
     "mock_PlanarMicroscopySeries",
     "mock_VariableDepthMicroscopySeries",
     "mock_VolumetricMicroscopySeries",
+    "mock_MultiChannelMicroscopyVolume",
 ]

--- a/src/pynwb/ndx_microscopy/testing/_mock.py
+++ b/src/pynwb/ndx_microscopy/testing/_mock.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 from pynwb.testing.mock.utils import name_generator
@@ -284,5 +284,36 @@ def mock_VolumetricMicroscopySeries(
         starting_time=series_starting_time,
         rate=series_rate,
         timestamps=series_timestamps,
+    )
+    return volumetric_microscopy_series
+
+
+def mock_MultiChannelMicroscopyVolume(
+    *,
+    microscope: ndx_microscopy.Microscope,
+    light_source: ndx_microscopy.LightSource,
+    imaging_space: ndx_microscopy.VolumetricImagingSpace,
+    optical_channels: List[ndx_microscopy.MicroscopyOpticalChannel],
+    name: Optional[str] = None,
+    description: str = "This is a mock instance of a MultiChannelMicroscopyVolume type to be used for rapid testing.",
+    data: Optional[np.ndarray] = None,
+    unit: str = "n.a.",
+    conversion: float = 1.0,
+    offset: float = 0.0,
+) -> ndx_microscopy.MultiChannelMicroscopyVolume:
+    series_name = name or name_generator("MultiChannelMicroscopyVolume")
+    imaging_data = data if data is not None else np.ones(shape=(10, 20, 7, 3))
+
+    volumetric_microscopy_series = ndx_microscopy.MultiChannelMicroscopyVolume(
+        name=series_name,
+        description=description,
+        microscope=microscope,
+        light_source=light_source,
+        imaging_space=imaging_space,
+        optical_channels=optical_channels[0],  # TODO: figure out how to specify list
+        data=imaging_data,
+        unit=unit,
+        conversion=conversion,
+        offset=offset,
     )
     return volumetric_microscopy_series

--- a/src/pynwb/tests/test_constructors.py
+++ b/src/pynwb/tests/test_constructors.py
@@ -6,6 +6,7 @@ from ndx_microscopy.testing import (
     mock_LightSource,
     mock_Microscope,
     mock_MicroscopyOpticalChannel,
+    mock_MultiChannelMicroscopyVolume,
     mock_PlanarImagingSpace,
     mock_PlanarMicroscopySeries,
     mock_VariableDepthMicroscopySeries,
@@ -68,6 +69,20 @@ def test_constructor_volumetric_microscopy_series():
 
     mock_VolumetricMicroscopySeries(
         microscope=microscope, light_source=light_source, imaging_space=imaging_space, optical_channel=optical_channel
+    )
+
+
+def test_constructor_multi_channel_microscopy_volume():
+    microscope = mock_Microscope()
+    light_source = mock_LightSource()
+    imaging_space = mock_VolumetricImagingSpace(microscope=microscope)
+    optical_channel = mock_MicroscopyOpticalChannel()
+
+    mock_MultiChannelMicroscopyVolume(
+        microscope=microscope,
+        light_source=light_source,
+        imaging_space=imaging_space,
+        optical_channels=[optical_channel],
     )
 
 

--- a/src/pynwb/tests/test_roundtrip.py
+++ b/src/pynwb/tests/test_roundtrip.py
@@ -133,7 +133,7 @@ class TestVariableDepthMicroscopySeriesSimpleRoundtrip(pynwb_TestCase):
         nwbfile.add_device(devices=light_source)
 
         imaging_space = mock_PlanarImagingSpace(name="PlanarImagingSpace", microscope=microscope)
-        nwbfile.add_lab_meta_data(lab_meta_data=imaging_space)  # Would prefer .add_imaging_spacec()
+        nwbfile.add_lab_meta_data(lab_meta_data=imaging_space)  # Would prefer .add_imaging_space()
 
         optical_channel = mock_MicroscopyOpticalChannel(name="MicroscopyOpticalChannel")
         nwbfile.add_lab_meta_data(lab_meta_data=optical_channel)
@@ -161,4 +161,54 @@ class TestVariableDepthMicroscopySeriesSimpleRoundtrip(pynwb_TestCase):
 
             self.assertContainerEqual(
                 variable_depth_microscopy_series, read_nwbfile.acquisition["VariableDepthMicroscopySeries"]
+            )
+
+
+class TestMultiChannelMicroscopyVolumeSimpleRoundtrip(pynwb_TestCase):
+    """Simple roundtrip test for MultiChannelMicroscopyVolume."""
+
+    def setUp(self):
+        self.nwbfile_path = "test.nwb"
+
+    def tearDown(self):
+        pynwb.testing.remove_test_file(self.nwbfile_path)
+
+    def test_roundtrip(self):
+        nwbfile = mock_NWBFile()
+
+        microscope = mock_Microscope(name="Microscope")
+        nwbfile.add_device(devices=microscope)
+
+        light_source = mock_LightSource(name="LightSource")
+        nwbfile.add_device(devices=light_source)
+
+        imaging_space = mock_VolumetricImagingSpace(name="VolumetricImagingSpace", microscope=microscope)
+        nwbfile.add_lab_meta_data(lab_meta_data=imaging_space)  # Would prefer .add_imaging_space()
+
+        optical_channel = mock_MicroscopyOpticalChannel(name="MicroscopyOpticalChannel")
+        nwbfile.add_lab_meta_data(lab_meta_data=optical_channel)
+
+        multi_channel_microscopy_volume = mock_MultiChannelMicroscopyVolume(
+            name="MultiChannelMicroscopyVolume",
+            microscope=microscope,
+            light_source=light_source,
+            imaging_space=imaging_space,
+            optical_channels=[optical_channel],
+        )
+        nwbfile.add_acquisition(nwbdata=multi_channel_microscopy_volume)
+
+        with pynwb.NWBHDF5IO(path=self.nwbfile_path, mode="w") as io:
+            io.write(nwbfile)
+
+        with pynwb.NWBHDF5IO(path=self.nwbfile_path, mode="r", load_namespaces=True) as io:
+            read_nwbfile = io.read()
+
+            self.assertContainerEqual(microscope, read_nwbfile.devices["Microscope"])
+            self.assertContainerEqual(light_source, read_nwbfile.devices["LightSource"])
+
+            self.assertContainerEqual(imaging_space, read_nwbfile.lab_meta_data["PlanarImagingSpace"])
+            self.assertContainerEqual(optical_channel, read_nwbfile.lab_meta_data["MicroscopyOpticalChannel"])
+
+            self.assertContainerEqual(
+                multi_channel_microscopy_volume, read_nwbfile.acquisition["MultiChannelMicroscopyVolume"]
             )


### PR DESCRIPTION
This pretty much completes the absorption of relevant parts of ndx-multichannel-volume into our microscopy metadata structure, with the exception we want to avoid of the 5D time + volume + channels object, which we can include in a follow-up if desired