### PR TITLE
Temporary rename to avoid collision

### DIFF
--- a/spec/ndx-microscopy.extensions.yaml
+++ b/spec/ndx-microscopy.extensions.yaml
@@ -9,7 +9,7 @@ groups:
         doc: Model identifier of the light source device.
         required: false
 
-  - neurodata_type_def: LightSource
+  - neurodata_type_def: MicroscopyLightSource
     neurodata_type_inc: Device
     doc: Light source used to illuminate an imaging space.
     attributes:
@@ -191,8 +191,8 @@ groups:
       doc: Link to a Microscope object containing metadata about the device used to acquire this imaging data.
       target_type: Microscope
     - name: light_source
-      doc: Link to a LightSource object containing metadata about the device used to illuminate the imaging space.
-      target_type: LightSource
+      doc: Link to a MicroscopyLightSource object containing metadata about the device used to illuminate the imaging space.
+      target_type: MicroscopyLightSource
     - name: optical_channel
       doc: Link to a MicroscopyOpticalChannel object containing metadata about the indicator and filters used to collect
         this data.

--- a/src/pynwb/ndx_microscopy/__init__.py
+++ b/src/pynwb/ndx_microscopy/__init__.py
@@ -21,7 +21,7 @@ if not os.path.exists(__spec_path):
 load_namespaces(str(__spec_path))
 
 Microscope = get_class("Microscope", extension_name)
-LightSource = get_class("LightSource", extension_name)
+MicroscopyLightSource = get_class("MicroscopyLightSource", extension_name)
 MicroscopyOpticalChannel = get_class("MicroscopyOpticalChannel", extension_name)
 ImagingSpace = get_class("ImagingSpace", extension_name)
 PlanarImagingSpace = get_class("PlanarImagingSpace", extension_name)
@@ -33,7 +33,7 @@ VolumetricMicroscopySeries = get_class("VolumetricMicroscopySeries", extension_n
 
 __all__ = [
     "Microscope",
-    "LightSource",
+    "MicroscopyLightSource",
     "MicroscopyOpticalChannel",
     "ImagingSpace",
     "PlanarImagingSpace",

--- a/src/pynwb/ndx_microscopy/testing/__init__.py
+++ b/src/pynwb/ndx_microscopy/testing/__init__.py
@@ -1,6 +1,6 @@
 from ._mock import (
-    mock_LightSource,
     mock_Microscope,
+    mock_MicroscopyLightSource,
     mock_MicroscopyOpticalChannel,
     mock_PlanarImagingSpace,
     mock_PlanarMicroscopySeries,
@@ -11,7 +11,7 @@ from ._mock import (
 
 __all__ = [
     "mock_Microscope",
-    "mock_LightSource",
+    "mock_MicroscopyLightSource",
     "mock_MicroscopyOpticalChannel",
     "mock_PlanarImagingSpace",
     "mock_VolumetricImagingSpace",

--- a/src/pynwb/ndx_microscopy/testing/_mock.py
+++ b/src/pynwb/ndx_microscopy/testing/_mock.py
@@ -23,10 +23,10 @@ def mock_Microscope(
     return microscope
 
 
-def mock_LightSource(
+def mock_MicroscopyLightSource(
     *,
     name: Optional[str] = None,
-    description: str = "This is a mock instance of a LightSource type to be used for rapid testing.",
+    description: str = "This is a mock instance of a MicroscopyLightSource type to be used for rapid testing.",
     manufacturer: str = "A fake manufacturer of the mock light source.",
     model: str = "A fake model of the mock light source.",
     filter_description: str = "A description about the fake filter used by the mock light source.",
@@ -36,9 +36,9 @@ def mock_LightSource(
     intensity_in_W_per_m2: float = 0.005,
     exposure_time_in_s: float = 2.51e-13,
     pulse_rate_in_Hz: float = 2.0e6,
-) -> ndx_microscopy.LightSource:
-    light_source = ndx_microscopy.LightSource(
-        name=name or name_generator("LightSource"),
+) -> ndx_microscopy.MicroscopyLightSource:
+    light_source = ndx_microscopy.MicroscopyLightSource(
+        name=name or name_generator("MicroscopyLightSource"),
         description=description,
         manufacturer=manufacturer,
         model=model,
@@ -118,7 +118,7 @@ def mock_VolumetricImagingSpace(
 def mock_PlanarMicroscopySeries(
     *,
     microscope: ndx_microscopy.Microscope,
-    light_source: ndx_microscopy.LightSource,
+    light_source: ndx_microscopy.MicroscopyLightSource,
     imaging_space: ndx_microscopy.PlanarImagingSpace,
     optical_channel: ndx_microscopy.MicroscopyOpticalChannel,
     name: Optional[str] = None,
@@ -173,7 +173,7 @@ def mock_PlanarMicroscopySeries(
 def mock_VariableDepthMicroscopySeries(
     *,
     microscope: ndx_microscopy.Microscope,
-    light_source: ndx_microscopy.LightSource,
+    light_source: ndx_microscopy.MicroscopyLightSource,
     imaging_space: ndx_microscopy.PlanarImagingSpace,
     optical_channel: ndx_microscopy.MicroscopyOpticalChannel,
     name: Optional[str] = None,
@@ -236,7 +236,7 @@ def mock_VariableDepthMicroscopySeries(
 def mock_VolumetricMicroscopySeries(
     *,
     microscope: ndx_microscopy.Microscope,
-    light_source: ndx_microscopy.LightSource,
+    light_source: ndx_microscopy.MicroscopyLightSource,
     imaging_space: ndx_microscopy.VolumetricImagingSpace,
     optical_channel: ndx_microscopy.MicroscopyOpticalChannel,
     name: Optional[str] = None,

--- a/src/pynwb/tests/test_constructors.py
+++ b/src/pynwb/tests/test_constructors.py
@@ -3,8 +3,8 @@
 import pytest
 
 from ndx_microscopy.testing import (
-    mock_LightSource,
     mock_Microscope,
+    mock_MicroscopyLightSource,
     mock_MicroscopyOpticalChannel,
     mock_PlanarImagingSpace,
     mock_PlanarMicroscopySeries,
@@ -19,7 +19,7 @@ def test_constructor_microscope():
 
 
 def test_constructor_light_source():
-    mock_LightSource()
+    mock_MicroscopyLightSource()
 
 
 def test_constructor_microscopy_optical_channel():
@@ -40,7 +40,7 @@ def test_constructor_volumetric_image_space():
 
 def test_constructor_planar_microscopy_series():
     microscope = mock_Microscope()
-    light_source = mock_LightSource()
+    light_source = mock_MicroscopyLightSource()
     imaging_space = mock_PlanarImagingSpace(microscope=microscope)
     optical_channel = mock_MicroscopyOpticalChannel()
 
@@ -51,7 +51,7 @@ def test_constructor_planar_microscopy_series():
 
 def test_constructor_variable_depth_microscopy_series():
     microscope = mock_Microscope()
-    light_source = mock_LightSource()
+    light_source = mock_MicroscopyLightSource()
     imaging_space = mock_PlanarImagingSpace(microscope=microscope)
     optical_channel = mock_MicroscopyOpticalChannel()
 
@@ -62,7 +62,7 @@ def test_constructor_variable_depth_microscopy_series():
 
 def test_constructor_volumetric_microscopy_series():
     microscope = mock_Microscope()
-    light_source = mock_LightSource()
+    light_source = mock_MicroscopyLightSource()
     imaging_space = mock_VolumetricImagingSpace(microscope=microscope)
     optical_channel = mock_MicroscopyOpticalChannel()
 

--- a/src/pynwb/tests/test_roundtrip.py
+++ b/src/pynwb/tests/test_roundtrip.py
@@ -5,8 +5,8 @@ from pynwb.testing.mock.file import mock_NWBFile
 
 import pynwb
 from ndx_microscopy.testing import (
-    mock_LightSource,
     mock_Microscope,
+    mock_MicroscopyLightSource,
     mock_MicroscopyOpticalChannel,
     mock_PlanarImagingSpace,
     mock_PlanarMicroscopySeries,
@@ -31,7 +31,7 @@ class TestPlanarMicroscopySeriesSimpleRoundtrip(pynwb_TestCase):
         microscope = mock_Microscope(name="Microscope")
         nwbfile.add_device(devices=microscope)
 
-        light_source = mock_LightSource(name="LightSource")
+        light_source = mock_MicroscopyLightSource(name="MicroscopyLightSource")
         nwbfile.add_device(devices=light_source)
 
         imaging_space = mock_PlanarImagingSpace(name="PlanarImagingSpace", microscope=microscope)
@@ -56,7 +56,7 @@ class TestPlanarMicroscopySeriesSimpleRoundtrip(pynwb_TestCase):
             read_nwbfile = io.read()
 
             self.assertContainerEqual(microscope, read_nwbfile.devices["Microscope"])
-            self.assertContainerEqual(light_source, read_nwbfile.devices["LightSource"])
+            self.assertContainerEqual(light_source, read_nwbfile.devices["MicroscopyLightSource"])
 
             self.assertContainerEqual(imaging_space, read_nwbfile.lab_meta_data["PlanarImagingSpace"])
             self.assertContainerEqual(optical_channel, read_nwbfile.lab_meta_data["MicroscopyOpticalChannel"])
@@ -79,7 +79,7 @@ class TestVolumetricMicroscopySeriesSimpleRoundtrip(pynwb_TestCase):
         microscope = mock_Microscope(name="Microscope")
         nwbfile.add_device(devices=microscope)
 
-        light_source = mock_LightSource(name="LightSource")
+        light_source = mock_MicroscopyLightSource(name="MicroscopyLightSource")
         nwbfile.add_device(devices=light_source)
 
         imaging_space = mock_VolumetricImagingSpace(name="VolumetricImagingSpace", microscope=microscope)
@@ -104,7 +104,7 @@ class TestVolumetricMicroscopySeriesSimpleRoundtrip(pynwb_TestCase):
             read_nwbfile = io.read()
 
             self.assertContainerEqual(microscope, read_nwbfile.devices["Microscope"])
-            self.assertContainerEqual(light_source, read_nwbfile.devices["LightSource"])
+            self.assertContainerEqual(light_source, read_nwbfile.devices["MicroscopyLightSource"])
 
             self.assertContainerEqual(imaging_space, read_nwbfile.lab_meta_data["VolumetricImagingSpace"])
             self.assertContainerEqual(optical_channel, read_nwbfile.lab_meta_data["MicroscopyOpticalChannel"])
@@ -129,7 +129,7 @@ class TestVariableDepthMicroscopySeriesSimpleRoundtrip(pynwb_TestCase):
         microscope = mock_Microscope(name="Microscope")
         nwbfile.add_device(devices=microscope)
 
-        light_source = mock_LightSource(name="LightSource")
+        light_source = mock_MicroscopyLightSource(name="MicroscopyLightSource")
         nwbfile.add_device(devices=light_source)
 
         imaging_space = mock_PlanarImagingSpace(name="PlanarImagingSpace", microscope=microscope)
@@ -154,7 +154,7 @@ class TestVariableDepthMicroscopySeriesSimpleRoundtrip(pynwb_TestCase):
             read_nwbfile = io.read()
 
             self.assertContainerEqual(microscope, read_nwbfile.devices["Microscope"])
-            self.assertContainerEqual(light_source, read_nwbfile.devices["LightSource"])
+            self.assertContainerEqual(light_source, read_nwbfile.devices["MicroscopyLightSource"])
 
             self.assertContainerEqual(imaging_space, read_nwbfile.lab_meta_data["PlanarImagingSpace"])
             self.assertContainerEqual(optical_channel, read_nwbfile.lab_meta_data["MicroscopyOpticalChannel"])


### PR DESCRIPTION
Smaller workaround to the more generic and extension fix of #12 to avoid a name collision when using both `ndx_microscopy` and `ndx_patterened_ogen`