### PR TITLE
Move ExcitationLightPath etc class def before where it's used

### DIFF
--- a/spec/ndx-microscopy.extensions.yaml
+++ b/spec/ndx-microscopy.extensions.yaml
@@ -265,11 +265,11 @@ groups:
       target_type: Microscope
     - name: excitation_light_path
       doc: Link to a ExcitationLightPath object containing metadata about the device used to illuminate the imaging space.
-      target_type: LabMetaData
+      target_type: ExcitationLightPath
     - name: emission_light_path
       doc: Link to a EmissionLightPath object containing metadata about the indicator and filters used to collect
         this data.
-      target_type: LabMetaData
+      target_type: EmissionLightPath
 
   - neurodata_type_def: PlanarMicroscopySeries
     neurodata_type_inc: MicroscopySeries
@@ -387,7 +387,7 @@ groups:
       neurodata_type_inc: VectorData
       dtype:
         reftype: object
-        target_type: LabMetaData
+        target_type: ExcitationLightPath
       dims:
         - excitation_light_paths
       shape:
@@ -397,7 +397,7 @@ groups:
       neurodata_type_inc: VectorData
       dtype:
         reftype: object
-        target_type: LabMetaData
+        target_type: EmissionLightPath
       dims:
         - emission_light_paths
       shape:
@@ -474,7 +474,7 @@ groups:
       neurodata_type_inc: VectorData
       dtype:
         reftype: object
-        target_type: LabMetaData
+        target_type: ExcitationLightPath
       dims:
         - excitation_light_paths
       shape:
@@ -484,7 +484,7 @@ groups:
       neurodata_type_inc: VectorData
       dtype:
         reftype: object
-        target_type: LabMetaData
+        target_type: EmissionLightPath
       dims:
         - emission_light_paths
       shape:

--- a/src/pynwb/ndx_microscopy/__init__.py
+++ b/src/pynwb/ndx_microscopy/__init__.py
@@ -24,6 +24,8 @@ if not os.path.exists(__spec_path):
 
 load_namespaces(str(__spec_path))
 
+from .ndx_microscopy import MicroscopyPlaneSegmentation, ExcitationLightPath, EmissionLightPath
+
 Microscope = get_class("Microscope", extension_name)
 
 ImagingSpace = get_class("ImagingSpace", extension_name)
@@ -42,7 +44,7 @@ MicroscopyResponseSeries = get_class("MicroscopyResponseSeries", extension_name)
 MicroscopyResponseSeriesContainer = get_class("MicroscopyResponseSeriesContainer", extension_name)
 
 MicroscopySegmentations = get_class("MicroscopySegmentations", extension_name)
-from .ndx_microscopy import MicroscopyPlaneSegmentation, ExcitationLightPath, EmissionLightPath
+# from .ndx_microscopy import MicroscopyPlaneSegmentation, ExcitationLightPath, EmissionLightPath
 
 __all__ = [
     "OpticalFilter",


### PR DESCRIPTION
Fix issue raised in #30

This PR moves the class definition and import of `ExcitationLightPath` and `EmissionLightPath` before the definition of the classes that they are used in. When they are imported after the definition of the classes X that they are used in, then when HDMF auto-generates a class for X, it also auto-generates a class for `ExcitationLightPath` and `EmissionLightPath`. That class is then overwritten with your custom class in `ndx_microscopy.py`, so the tests fail because classes X expect the auto-generated class not your custom class.

