### PR TITLE
Fix version in ndx-microscopy.namespace.yaml and bump to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.2.1 (March 28, 2025)
+
+## Bug Fixes
+- Fixed version in namespace YAML file and docs
+
 # v0.2.0 (March 19, 2025)
 
 ## Deprecations and Changes

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@ project = 'ndx-microscopy'
 copyright = '2024, Alessandra Trapani, Cody Baker'
 author = 'Alessandra Trapani, Cody Baker'
 
-version = '0.1.0'
+version = '0.2.1'
 release = 'alpha'
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ndx-microscopy"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     { name="Alessandra Trapani", email="alessandra.trapani@catalystneuro.com" },
     { name="Cody Baker", email="cody.baker@catalystneuro.com" },

--- a/spec/ndx-microscopy.namespace.yaml
+++ b/spec/ndx-microscopy.namespace.yaml
@@ -27,4 +27,4 @@ namespaces:
           - Photodetector
           - DichroicMirror
       - source: ndx-microscopy.extensions.yaml
-    version: 0.1.0
+    version: 0.2.1


### PR DESCRIPTION
The version in the namespace file is still 0.1.0 even though the version of the package is now 0.2.0. Since updating the version in the namespace file is a change, I propose bumping the version of the package (in all places) to 0.2.1.